### PR TITLE
refactor(dimoapi): parse token expiry from jwt.

### DIFF
--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -12,7 +12,6 @@ class PrivilegedToken:
     """Class to hold privileged tokens."""
 
     token: str
-    token_expiry: float = 0
 
 
 class Auth:
@@ -34,11 +33,8 @@ class Auth:
             token = self.dimo.token_exchange.exchange(
                 self.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
             )
-            token_expiry = time.time() + 600
 
-            self.privileged_tokens[vehicle_token_id] = PrivilegedToken(
-                token, token_expiry
-            )
+            self.privileged_tokens[vehicle_token_id] = PrivilegedToken(token)
             logger.debug("New privileged token obtained")
 
         return self.privileged_tokens[vehicle_token_id].token

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import requests
 import dimo as dimo_api
 import time
-import datetime
+from datetime import datetime, timezone
 from loguru import logger
 import jwt
 
@@ -50,6 +50,7 @@ class Auth:
             if exp:
                 expiration_time = datetime.fromtimestamp(exp, timezone.utc)
                 current_time = datetime.now(timezone.utc)
+
                 return current_time > expiration_time
         return True
 

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -48,9 +48,9 @@ class Auth:
             )
             exp = decoded_token.get("exp")
             if exp:
-                expiration_time = datetime.datetime.utcfromtimestamp(exp)
-                current_time = datetime.datetime.utcnow()
-                return current_time >= expiration_time
+                expiration_time = datetime.fromtimestamp(exp, timezone.utc)
+                current_time = datetime.now(timezone.utc)
+                return current_time > expiration_time
         return True
 
     def _get_auth(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -143,3 +143,18 @@ def test_is_privileged_token_not_expired(mocker):
 
     # Test the method
     assert not auth_instance._is_privileged_token_expired(vehicle_token_id)
+
+
+def test_is_privileged_token_expired():
+    # Create an instance of Auth
+    auth_instance = Auth("client_id", "domain", "private_key")
+    vehicle_token_id = "123"
+
+    # Generate an expired token (expired 10 minutes ago)
+    jwt_value = create_mock_token(-600)  # Negative offset indicates past expiry
+    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(
+        {"token": jwt_value}
+    )
+
+    # Assert the token is recognized as expired
+    assert auth_instance._is_privileged_token_expired(vehicle_token_id)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,7 +10,6 @@ from custom_components.dimo.dimoapi.auth import (
     InvalidClientIdError,
     InvalidCredentialsError,
 )
-from astral import now
 
 
 def test_auth_get_token(mocker):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,12 +1,16 @@
+import jwt
 import requests
+from datetime import datetime, timedelta, timezone
 import pytest
 from unittest.mock import Mock
 from custom_components.dimo.dimoapi import DimoClient, Auth
 from custom_components.dimo.dimoapi.auth import (
+    PrivilegedToken,
     InvalidApiKeyFormat,
     InvalidClientIdError,
     InvalidCredentialsError,
 )
+from astral import now
 
 
 def test_auth_get_token(mocker):
@@ -117,3 +121,26 @@ def test_auth_exceptions(mocker, mocked_exception, expected_exception):
 
     with pytest.raises(expected_exception):
         auth.get_token()
+
+
+def create_mock_token(exp_offset):
+    """
+    Helper function to create a mock JWT token with a specific expiration offset.
+    """
+    expiration_time = datetime.now(timezone.utc) + timedelta(seconds=exp_offset)
+    payload = {"exp": expiration_time.timestamp()}
+    return jwt.encode(payload, "secret", algorithm="HS256")
+
+
+def test_is_privileged_token_not_expired(mocker):
+    # Mock the instance and its privileged tokens
+    auth_instance = Auth("client_id", "domain", "private_key")
+    vehicle_token_id = "123"
+    token = create_mock_token(600)  # Expires in 10 minutes
+
+    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(
+        {"token": token}
+    )
+
+    # Test the method
+    assert not auth_instance._is_privileged_token_expired(vehicle_token_id)


### PR DESCRIPTION
instead of relying on a hardcoded 10 minute expiration, we parse the jwt and retrieve the expiration timestamp from the token directly.

Fixes #52
References #45