### PR TITLE
deps: bump dimo sdk to v0.0.7

### DIFF
--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
-    "dimo-python-sdk==0.0.7",
+    "ha-dimo-python-sdk==0.0.8",
     "loguru==0.7.2"
   ],
   "single_config_entry": true,

--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
-    "dimo-python-sdk==0.0.6",
+    "dimo-python-sdk==0.0.7",
     "loguru==0.7.2"
   ],
   "single_config_entry": true,

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 coverage==7.6.1
-dimo-python-sdk==0.0.5
+dimo-python-sdk==0.0.7
 eth-account==0.11.3
 loguru==0.7.2
 pytest-mock==3.14.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 coverage==7.6.1
-dimo-python-sdk==0.0.7
+ha-dimo-python-sdk==0.0.8
 loguru==0.7.2
 pytest-mock==3.14.0
 pytest-homeassistant-custom-component==0.13.183

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 coverage==7.6.1
 dimo-python-sdk==0.0.7
-eth-account==0.11.3
 loguru==0.7.2
 pytest-mock==3.14.0
 pytest-homeassistant-custom-component==0.13.183


### PR DESCRIPTION
Use the fork by @msp1974 that removes the need for pydantic. Home Assistant core has now finally merged a PR that updates `pydantic` but this won't be available to users until 2015.1 release, so we can use the fork until then.

References #64 