### PR TITLE
fix: corrected state class for total dimo vehicles sensor.

### DIFF
--- a/custom_components/dimo/const.py
+++ b/custom_components/dimo/const.py
@@ -54,7 +54,7 @@ DIMO_SENSORS = {
         Platform.SENSOR,
         icon="mdi:counter",
         value_fn="get_total_dimo_vehicles",
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
     )
 }
 


### PR DESCRIPTION
the number of total vehicles on DIMO can (unfortunately), go down, so we shouldn't use a state class that presumes the count always goes up.

Fixes #80