### PR TITLE
refactor: replaced loguru with standard logging.

### DIFF
--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -3,8 +3,10 @@ import requests
 import dimo as dimo_api
 import time
 from datetime import datetime, timezone
-from loguru import logger
 import jwt
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -30,7 +32,7 @@ class Auth:
         if not self.privileged_tokens.get(
             vehicle_token_id
         ) or self._is_privileged_token_expired(vehicle_token_id):
-            logger.debug(f"Obtaining privileged token for {vehicle_token_id}")
+            _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
             token = self.dimo.token_exchange.exchange(
                 self.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
             )
@@ -55,7 +57,7 @@ class Auth:
         return True
 
     def _get_auth(self):
-        logger.debug("Retrieving access token")
+        _LOGGER.debug("Retrieving access token")
         try:
             auth_header = self.dimo.auth.get_token(
                 client_id=self.client_id,
@@ -63,7 +65,7 @@ class Auth:
                 private_key=self.private_key,
             )
             self.token = auth_header["access_token"]
-            logger.debug("access token retrieved")
+            _LOGGER.debug("access token retrieved")
         except requests.exceptions.HTTPError as e:
             if "404" in str(e):
                 raise InvalidClientIdError from e

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -1,4 +1,4 @@
-from loguru import logger
+import logging
 from .auth import Auth
 from .queries import (
     GET_VEHICLE_REWARDS_QUERY,
@@ -6,6 +6,8 @@ from .queries import (
     GET_LATEST_SIGNALS_QUERY,
     GET_ALL_VEHICLES_QUERY,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DimoClient:
@@ -18,7 +20,7 @@ class DimoClient:
         try:
             self.auth.get_token()
         except Exception as e:
-            logger.error(f"Failed to init Dimo client: {e}")
+            _LOGGER.error(f"Failed to init Dimo client: {e}")
             raise
 
     def _fetch_privileged_token(self, token_id: str) -> str:
@@ -26,7 +28,7 @@ class DimoClient:
         try:
             return self.auth.get_privileged_token(token_id)
         except Exception as e:
-            logger.error(f"Failed to obtain privileged token for {token_id}: {e}")
+            _LOGGER.error(f"Failed to obtain privileged token for {token_id}: {e}")
             raise
 
     def get_vehicle_makes(self):

--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
-    "ha-dimo-python-sdk==0.0.8",
+    "ha-dimo-python-sdk==0.0.8"
   ],
   "single_config_entry": true,
   "version": "0.2.0"

--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -11,7 +11,6 @@
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
     "ha-dimo-python-sdk==0.0.8",
-    "loguru==0.7.2"
   ],
   "single_config_entry": true,
   "version": "0.2.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,4 @@
 coverage==7.6.1
 ha-dimo-python-sdk==0.0.8
-loguru==0.7.2
 pytest-mock==3.14.0
 pytest-homeassistant-custom-component==0.13.183


### PR DESCRIPTION
In a Home Assistant integration, it’s more typical to rely on the built-in logging library. This ensures consistent formatting, log levels, and it cooperates with Home Assistant’s logging system.

Using a single logger across your integration is cleaner, and Home Assistant dev guidelines also advise against mixing multiple logging libraries.