### PR TITLE
refactor: store only the privileged token string.

### DIFF
--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -44,7 +44,7 @@ class Auth:
             _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
             token = self.dimo.token_exchange.exchange(
                 self.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
-            )
+            )["token"]
 
             self.privileged_tokens[vehicle_token_id] = PrivilegedToken(token)
 
@@ -54,7 +54,7 @@ class Auth:
         """Assert privileged token expiration."""
         if self.privileged_tokens.get(vehicle_token_id):
             decoded_token = jwt.decode(
-                self.privileged_tokens[vehicle_token_id].token["token"],
+                self.privileged_tokens[vehicle_token_id].token,
                 options={"verify_signature": False},
             )
             exp = decoded_token.get("exp")

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -51,7 +51,7 @@ class DimoClient:
         """Get list of available signals for a specified vehicle"""
         priv_token = self._fetch_privileged_token(token_id)
         query = GET_AVAILABLE_SIGNALS_QUERY.format(token_id=token_id)
-        return self.dimo.telemetry.query(query, priv_token["token"])
+        return self.dimo.telemetry.query(query, priv_token)
 
     def get_latest_signals(self, token_id, signal_names: list[str]):
         """Get the latest signal values for the specified vehicle"""
@@ -66,7 +66,7 @@ class DimoClient:
         query = GET_LATEST_SIGNALS_QUERY.format(
             token_id=token_id, signals=signals_query
         )
-        return self.dimo.telemetry.query(query, priv_token["token"])
+        return self.dimo.telemetry.query(query, priv_token)
 
     def get_all_vehicles_for_license(self, license_id=None):
         """List all vehicles for the specified license."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -86,11 +86,12 @@ def test_auth_get_token_calls_get_auth_when_token_is_none(mocker):
 
 def test_auth_get_privileged_token(mocker):
     fake_privileged_token = "privileged_token_1234"
+    fake_response = {"token": fake_privileged_token}
     vehicle_token_id = "1337"
 
     # Mock DIMO instance and token_exchange
     dimo_mock = Mock()
-    dimo_mock.token_exchange.exchange = Mock(return_value=fake_privileged_token)
+    dimo_mock.token_exchange.exchange = Mock(return_value=fake_response)
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
     auth.token = "current_token"
@@ -137,9 +138,7 @@ def test_is_privileged_token_not_expired(mocker):
     vehicle_token_id = "123"
     token = create_mock_token(600)  # Expires in 10 minutes
 
-    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(
-        {"token": token}
-    )
+    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(token)
 
     # Test the method
     assert not auth_instance._is_privileged_token_expired(vehicle_token_id)
@@ -152,9 +151,7 @@ def test_is_privileged_token_expired():
 
     # Generate an expired token (expired 10 minutes ago)
     jwt_value = create_mock_token(-600)  # Negative offset indicates past expiry
-    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(
-        {"token": jwt_value}
-    )
+    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(jwt_value)
 
     # Assert the token is recognized as expired
     assert auth_instance._is_privileged_token_expired(vehicle_token_id)

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -57,7 +57,7 @@ query GetVehicleRewardsByTokenId {{
 def test_dimo_client_get_available_signals():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
-    priv_token = {"token": "privileged_token_123"}
+    priv_token = "privileged_token_123"
     auth_mock.get_privileged_token.return_value = priv_token
 
     dimo_client = DimoClient(auth=auth_mock)
@@ -75,7 +75,7 @@ query AvailableSignals {{
   availableSignals(tokenId: {token_id})
 }}
 """,
-        priv_token["token"],
+        priv_token,
     )
     auth_mock.get_privileged_token.assert_called_once_with(token_id)
 
@@ -83,7 +83,7 @@ query AvailableSignals {{
 def test_dimo_client_get_latest_signals():
     auth_mock = Mock()
     dimo_mock = Mock()
-    priv_token = {"token": "privileged_token_123"}
+    priv_token = "privileged_token_123"
     auth_mock.get_privileged_token.return_value = priv_token
 
     dimo_client = DimoClient(auth=auth_mock)

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -127,5 +127,5 @@ def test_dimo_client_get_latest_signals():
     ), f"Query mismatch.\nExpected:\n{expected_query}\nActual:\n{actual_query}"
 
     # Ensure privileged token was used
-    dimo_mock.telemetry.query.assert_called_once_with(actual_query, priv_token["token"])
+    dimo_mock.telemetry.query.assert_called_once_with(actual_query, priv_token)
     auth_mock.get_privileged_token.assert_called_once_with(token_id)


### PR DESCRIPTION
no need to store the entire json response (for now). it creates pointless confusion.