### PR TITLE
refactor: unify access token management

### DIFF
--- a/custom_components/dimo/__init__.py
+++ b/custom_components/dimo/__init__.py
@@ -157,7 +157,7 @@ class DimoUpdateCoordinator(DataUpdateCoordinator):
     async def get_user_data(self):
         """Get and store user data."""
         self.user_data = await self.get_api_data(
-            self.client.dimo.user.user, self.client.auth.token
+            self.client.dimo.user.user, self.client.auth.access_token.token
         )
 
     async def get_vehicles_data(self):

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -15,7 +15,7 @@ class AuthToken:
 
     token: str
 
-    def get_expiration(self):
+    def get_expiration(self) -> float:
         """Parse and return expiration timestamp from token"""
         decoded_token = jwt.decode(
             self.token,
@@ -24,7 +24,7 @@ class AuthToken:
         exp = decoded_token.get("exp")
         if exp:
             return exp
-        return 0
+        return float(0)
 
 
 class Auth:
@@ -63,7 +63,7 @@ class Auth:
 
     def _is_jwt_token_expired(self, token: AuthToken) -> bool:
         """Assert jwt token expiration"""
-        exp = token.get_expiration
+        exp = token.get_expiration()
         expiration_time = datetime.fromtimestamp(exp, timezone.utc)
         current_time = datetime.now(timezone.utc)
 
@@ -98,7 +98,7 @@ class Auth:
         except ValueError as e:
             raise InvalidApiKeyFormat from e
 
-    def get_token(self) -> AuthToken:
+    def get_access_token(self) -> AuthToken:
         """
         Get the DIMO API access token.
         Will obtain a fresh token if no token exists or if

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -54,7 +54,9 @@ class Auth:
         ) or self._is_privileged_token_expired(vehicle_token_id):
             _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
             token = self.dimo.token_exchange.exchange(
-                self.access_token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
+                self.access_token.token,
+                privileges=[1, 2, 3, 4],
+                token_id=vehicle_token_id,
             )["token"]
 
             self.privileged_tokens[vehicle_token_id] = AuthToken(token)

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -10,10 +10,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class PrivilegedToken:
-    """Class to hold privileged tokens."""
+class AuthToken:
+    """Class to hold JWT based authentication tokens."""
 
     token: str
+
+    def get_expiration(self):
+        """Parse and return expiration timestamp from token"""
+        decoded_token = jwt.decode(
+            self.token,
+            options={"verify_signature": False},
+        )
+        exp = decoded_token.get("exp")
+        if exp:
+            return exp
+        return 0
 
 
 class Auth:
@@ -32,8 +43,8 @@ class Auth:
         self.client_id = client_id
         self.domain = domain
         self.private_key = private_key
-        self.token = None
-        self.privileged_tokens: dict[str, PrivilegedToken] = {}
+        self.access_token = None
+        self.privileged_tokens: dict[str, AuthToken] = {}
         self.dimo = dimo if dimo else dimo_api.DIMO("Production")
 
     def get_privileged_token(self, vehicle_token_id: str) -> str:
@@ -43,33 +54,26 @@ class Auth:
         ) or self._is_privileged_token_expired(vehicle_token_id):
             _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
             token = self.dimo.token_exchange.exchange(
-                self.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
+                self.access_token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
             )["token"]
 
-            self.privileged_tokens[vehicle_token_id] = PrivilegedToken(token)
+            self.privileged_tokens[vehicle_token_id] = AuthToken(token)
 
         return self.privileged_tokens[vehicle_token_id].token
 
-    def _is_jwt_token_expired(self, token: str) -> bool:
+    def _is_jwt_token_expired(self, token: AuthToken) -> bool:
         """Assert jwt token expiration"""
-        decoded_token = jwt.decode(
-            token,
-            options={"verify_signature": False},
-        )
-        exp = decoded_token.get("exp")
-        if exp:
-            expiration_time = datetime.fromtimestamp(exp, timezone.utc)
-            current_time = datetime.now(timezone.utc)
+        exp = token.get_expiration
+        expiration_time = datetime.fromtimestamp(exp, timezone.utc)
+        current_time = datetime.now(timezone.utc)
 
-            return current_time > expiration_time
-
-        return True
+        return current_time > expiration_time
 
     def _is_privileged_token_expired(self, vehicle_token_id: str) -> bool:
         """Assert privileged token expiration."""
         if self.privileged_tokens.get(vehicle_token_id):
             return self._is_jwt_token_expired(
-                self.privileged_tokens.get(vehicle_token_id).token
+                self.privileged_tokens.get(vehicle_token_id)
             )
 
         return True
@@ -82,7 +86,7 @@ class Auth:
                 domain=self.domain,
                 private_key=self.private_key,
             )
-            self.token = auth_header["access_token"]
+            self.access_token = AuthToken(auth_header["access_token"])
             _LOGGER.debug("access token retrieved")
         except requests.exceptions.HTTPError as e:
             if "404" in str(e):
@@ -94,15 +98,15 @@ class Auth:
         except ValueError as e:
             raise InvalidApiKeyFormat from e
 
-    def get_token(self):
+    def get_token(self) -> AuthToken:
         """
         Get the DIMO API access token.
         Will obtain a fresh token if no token exists or if
         the current token is expired
         """
-        if self.token is None or self._is_jwt_token_expired(self.token):
+        if self.access_token is None or self._is_jwt_token_expired(self.access_token):
             self._get_auth()
-        return self.token
+        return self.access_token
 
     def get_dimo(self):
         """

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -18,7 +18,7 @@ class DimoClient:
     def init(self) -> None:
         """Initialize the client by retrieving an authorization token"""
         try:
-            self.auth.get_token()
+            self.auth.get_access_token()
         except Exception as e:
             _LOGGER.error(f"Failed to init Dimo client: {e}")
             raise

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import Mock
 from custom_components.dimo.dimoapi import DimoClient, Auth
 from custom_components.dimo.dimoapi.auth import (
-    PrivilegedToken,
+    AuthToken,
     InvalidApiKeyFormat,
     InvalidClientIdError,
     InvalidCredentialsError,
@@ -13,15 +13,15 @@ from custom_components.dimo.dimoapi.auth import (
 
 
 def test_auth_get_token(mocker):
-    fake_token = "abcdef1234"
+    fake_token = AuthToken("abcdef1234")
     # Mocking the DIMO instance and auth.get_token
     dimo_mock = Mock()
-    dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token})
 
+    dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token.token})
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
 
     # Test token retrieval
-    token = auth.get_token()
+    token = auth.get_access_token()
 
     assert token == fake_token
     dimo_mock.auth.get_token.assert_called_once_with(
@@ -48,15 +48,15 @@ def test_dimo_client_get_vehicle_makes(mocker):
 
 def test_auth_token_caching(mocker):
     # Mock DIMO instance and auth.get_token
-    fake_token = create_mock_token(3600)
+    fake_token = AuthToken(create_mock_token(3600))
     dimo_mock = Mock()
     dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token})
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
-    auth.token = fake_token  # Simulate an already set token
+    auth.access_token = fake_token  # Simulate an already set token
 
     # Ensure that get_token does not call _get_auth if token is already set
-    token = auth.get_token()
+    token = auth.get_access_token()
 
     assert token == fake_token
     dimo_mock.auth.get_token.assert_not_called()
@@ -70,13 +70,13 @@ def test_auth_get_dimo():
 
 
 def test_auth_get_token_calls_get_auth_when_token_is_none(mocker):
-    fake_token = create_mock_token(3600)  # 1 hour from now
+    fake_token = AuthToken(create_mock_token(3600))  # 1 hour from now
     dimo_mock = Mock()
-    dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token})
+    dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token.token})
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
 
-    token = auth.get_token()
+    token = auth.get_access_token()
 
     assert token == fake_token
     dimo_mock.auth.get_token.assert_called_once_with(
@@ -94,14 +94,14 @@ def test_auth_get_privileged_token(mocker):
     dimo_mock.token_exchange.exchange = Mock(return_value=fake_response)
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
-    auth.token = "current_token"
+    auth.access_token = "current_token"
 
     # Test privileged token retrieval
     privileged_token = auth.get_privileged_token(vehicle_token_id)
 
     assert privileged_token == fake_privileged_token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
-        auth.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
+        auth.access_token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
     )
 
 
@@ -120,7 +120,7 @@ def test_auth_exceptions(mocker, mocked_exception, expected_exception):
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
 
     with pytest.raises(expected_exception):
-        auth.get_token()
+        auth.get_access_token()
 
 
 def create_mock_token(exp_offset):
@@ -138,7 +138,7 @@ def test_is_privileged_token_not_expired(mocker):
     vehicle_token_id = "123"
     token = create_mock_token(600)  # Expires in 10 minutes
 
-    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(token)
+    auth_instance.privileged_tokens[vehicle_token_id] = AuthToken(token)
 
     # Test the method
     assert not auth_instance._is_privileged_token_expired(vehicle_token_id)
@@ -151,24 +151,24 @@ def test_is_privileged_token_expired():
 
     # Generate an expired token (expired 10 minutes ago)
     jwt_value = create_mock_token(-600)  # Negative offset indicates past expiry
-    auth_instance.privileged_tokens[vehicle_token_id] = PrivilegedToken(jwt_value)
+    auth_instance.privileged_tokens[vehicle_token_id] = AuthToken(jwt_value)
 
     # Assert the token is recognized as expired
     assert auth_instance._is_privileged_token_expired(vehicle_token_id)
 
 
-def test_main_token_not_refreshed_if_not_expired(mocker):
-    """Ensures we don't refresh the main token if it's still valid."""
+def test_access_token_not_refreshed_if_not_expired(mocker):
+    """Ensures we don't refresh the access token if it's still valid."""
     dimo_mock = Mock()
     # Make sure if we do fetch, it would be some placeholder
     dimo_mock.auth.get_token = Mock(return_value={"access_token": "unused_new_token"})
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
-    valid_token = create_mock_token(3600)  # 1 hour from now
-    auth.token = valid_token
+    valid_token = AuthToken(create_mock_token(3600))  # 1 hour from now
+    auth.access_token = valid_token
 
     # This call should NOT trigger a refresh
-    token = auth.get_token()
+    token = auth.get_access_token()
 
     assert token == valid_token
     dimo_mock.auth.get_token.assert_not_called()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -94,14 +94,14 @@ def test_auth_get_privileged_token(mocker):
     dimo_mock.token_exchange.exchange = Mock(return_value=fake_response)
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
-    auth.access_token = "current_token"
+    auth.access_token = AuthToken("current_token")
 
     # Test privileged token retrieval
     privileged_token = auth.get_privileged_token(vehicle_token_id)
 
     assert privileged_token == fake_privileged_token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
-        auth.access_token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
+        auth.access_token.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
     )
 
 

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -11,7 +11,7 @@ def test_dimo_client_init():
     dimo_client.init()
 
     # Assert: Verify interactions
-    auth_mock.get_token.assert_called_once()
+    auth_mock.get_access_token.assert_called_once()
 
 
 def test_dimo_client_get_vehicle_makes():


### PR DESCRIPTION
access tokens and privileged tokens are both JWT tokens and can hence be handled in the same way, including evaluating token expiration.