### PR TITLE
refactor: disable entity polling.

### DIFF
--- a/custom_components/dimo/binary_sensor.py
+++ b/custom_components/dimo/binary_sensor.py
@@ -53,6 +53,11 @@ class DimoBinarySensorEntity(DimoBaseEntity, BinarySensorEntity):
     """Binary Sensor entity."""
 
     @property
+    def should_poll(self) -> bool:
+        """Disable polling; updates come from the coordinator"""
+        return False
+
+    @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.coordinator.dimo_data.get(self.key)
@@ -60,6 +65,11 @@ class DimoBinarySensorEntity(DimoBaseEntity, BinarySensorEntity):
 
 class DimoVehicleBinarySensorEntity(DimoBaseVehicleEntity, BinarySensorEntity):
     """Binary Sensor entity."""
+
+    @property
+    def should_poll(self) -> bool:
+        """Disable polling; updates come from the coordinator"""
+        return False
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/dimo/sensor.py
+++ b/custom_components/dimo/sensor.py
@@ -55,6 +55,11 @@ class DimoSensorEntity(DimoBaseEntity, SensorEntity):
     """Dimo sensor entity."""
 
     @property
+    def should_poll(self) -> bool:
+        """Disable polling; updates come from the coordinator"""
+        return False
+
+    @property
     def native_value(self):
         """Return the native value of this entity."""
         return self.coordinator.dimo_data.get(self.key)
@@ -71,6 +76,11 @@ class DimoSensorEntity(DimoBaseEntity, SensorEntity):
 
 class DimoVehicleSensorEntity(DimoBaseVehicleEntity, SensorEntity):
     """Vehicle Sensor entity."""
+
+    @property
+    def should_poll(self) -> bool:
+        """Disable polling; updates come from the coordinator"""
+        return False
 
     @property
     def native_value(self):


### PR DESCRIPTION
As the integration uses a `DataUpdateCoordinator` to fetch new data on the specified schedule. Home Assistant therefore does not need to poll each individual entity.