### PR TITLE
refactor: simplify and streamline privileged token parsing.

### DIFF
--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -44,7 +44,7 @@ class Auth:
         self.privileged_tokens: dict[str, AuthToken] = {}
         self.dimo = dimo if dimo else dimo_api.DIMO("Production")
 
-    def get_privileged_token(self, vehicle_token_id: str) -> str:
+    def get_privileged_token(self, vehicle_token_id: str) -> AuthToken:
         """Get privileged token from DIMO token exchange API"""
         if not self.privileged_tokens.get(
             vehicle_token_id
@@ -58,7 +58,7 @@ class Auth:
 
             self.privileged_tokens[vehicle_token_id] = AuthToken(token)
 
-        return self.privileged_tokens[vehicle_token_id].token
+        return self.privileged_tokens[vehicle_token_id]
 
     def _is_jwt_token_expired(self, token: AuthToken) -> bool:
         """Assert jwt token expiration"""

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -27,7 +27,7 @@ class DimoClient:
     def _fetch_privileged_token(self, token_id: str) -> str:
         """Retrieve privileged token for specified token id"""
         try:
-            return self.auth.get_privileged_token(token_id)
+            return self.auth.get_privileged_token(token_id).token
         except Exception as e:
             _LOGGER.error(f"Failed to obtain privileged token for {token_id}: {e}")
             raise

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,12 @@
+import jwt
+from datetime import datetime, timedelta, timezone
+from custom_components.dimo.dimoapi.auth import AuthToken
+
+
+def create_mock_token(exp_offset) -> AuthToken:
+    """
+    Helper function to create a mock JWT token with a specific expiration offset.
+    """
+    expiration_time = datetime.now(timezone.utc) + timedelta(seconds=exp_offset)
+    payload = {"exp": expiration_time.timestamp()}
+    return AuthToken(jwt.encode(payload, "secret", algorithm="HS256"))


### PR DESCRIPTION
handle the privileged token as AuthToken objects the same way we handle the access token