### PR TITLE
refactor: inherit from HomeAssistantError

### DIFF
--- a/custom_components/dimo/config_flow.py
+++ b/custom_components/dimo/config_flow.py
@@ -104,5 +104,5 @@ class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
 
 
-class NoVehiclesException(BaseException):
+class NoVehiclesException(HomeAssistantError):
     """Error to indicate no vehicles on the account."""


### PR DESCRIPTION
It is best practice to derive from Exception or HomeAssistantError so that it is caught by general exception handlers.