### PR TITLE
feat: added vehicle vin to device registry entry

### DIFF
--- a/custom_components/dimo/__init__.py
+++ b/custom_components/dimo/__init__.py
@@ -224,7 +224,6 @@ class DimoUpdateCoordinator(DataUpdateCoordinator):
         """Retrieve VIN for a vehicle"""
         _LOGGER.debug("Retrieving VIN for %s", vehicle_token_id)
         try:
-
             vin = await self.get_api_data(self.client.get_vin, vehicle_token_id)
             if vin:
                 self.vehicle_data[vehicle_token_id].vin = vin

--- a/custom_components/dimo/base_entity.py
+++ b/custom_components/dimo/base_entity.py
@@ -10,8 +10,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DimoUpdateCoordinator
-from .const import DIMO_SENSORS, SIGNALS
+from .const import DIMO_SENSORS, SIGNALS, DOMAIN
 from custom_components.dimo.const import SignalDef
+from custom_components.dimo import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -98,6 +99,25 @@ class DimoBaseVehicleEntity(DimoBaseEntity):
         """Return extra state attributes."""
         vehicle_data = self.coordinator.vehicle_data[self.vehicle_token_id]
         signal_data = vehicle_data.signal_data.get(self.key, {})
-        return {
-            "timestamp": signal_data.get("timestamp"),
-        }
+
+        extra_attr = {"timestamp": signal_data.get("timestamp")}
+
+        return extra_attr
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for the vehicle, including its VIN if available."""
+        vehicle = self.coordinator.vehicle_data[self.vehicle_token_id]
+        identifiers = {(DOMAIN, self.vehicle_token_id)}
+        vin = ""
+        if vehicle.vin:
+            identifiers.add((DOMAIN, vehicle.vin))
+            vin = vehicle.vin
+
+        return DeviceInfo(
+            identifiers=identifiers,
+            manufacturer=vehicle.definition.get("make", "DIMO"),
+            name=f"{vehicle.definition.get('make', 'Unknown')} {vehicle.definition.get('model', 'Unknown')}",
+            model=vehicle.definition.get("model", "Unknown Model"),
+            serial_number=vin,
+        )

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -44,15 +44,22 @@ class Auth:
         self.privileged_tokens: dict[str, AuthToken] = {}
         self.dimo = dimo if dimo else dimo_api.DIMO("Production")
 
-    def get_privileged_token(self, vehicle_token_id: str) -> AuthToken:
+    def get_privileged_token(
+        self, vehicle_token_id: str, permissions: Optional[list]
+    ) -> AuthToken:
         """Get privileged token from DIMO token exchange API"""
         if not self.privileged_tokens.get(
             vehicle_token_id
         ) or self._is_privileged_token_expired(vehicle_token_id):
-            _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
+            if permissions is None:
+                _LOGGER.debug("No permissions specified. Fallback to default")
+                permissions = [1, 2, 3, 4, 5, 6]
+            _LOGGER.debug(
+                f"Obtaining privileged token for {vehicle_token_id} with privileges {permissions}"
+            )
             token = self.dimo.token_exchange.exchange(
                 self.access_token.token,
-                privileges=[1, 2, 3, 4, 5],
+                privileges=permissions,
                 token_id=vehicle_token_id,
             )["token"]
 

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -52,7 +52,7 @@ class Auth:
             _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
             token = self.dimo.token_exchange.exchange(
                 self.access_token.token,
-                privileges=[1, 2, 3, 4],
+                privileges=[1, 2, 3, 4, 5],
                 token_id=vehicle_token_id,
             )["token"]
 

--- a/custom_components/dimo/dimoapi/queries.py
+++ b/custom_components/dimo/dimoapi/queries.py
@@ -34,3 +34,16 @@ query VehiclesForLicense {{
   }}
 }}
 """
+
+CHECK_SACD_QUERY = """
+  query CheckSACD {{
+  vehicle(tokenId: {token_id}) {{
+    sacds(first:100) {{
+      nodes {{
+        permissions
+        grantee
+      }}
+    }}
+  }}
+}}
+"""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -104,7 +104,7 @@ def test_auth_get_privileged_token(mocker):
 
     assert privileged_token.token == fake_privileged_token.token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
-        auth.access_token.token, privileges=[1, 2, 3, 4], token_id=vehicle_token_id
+        auth.access_token.token, privileges=[1, 2, 3, 4, 5], token_id=vehicle_token_id
     )
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -91,6 +91,7 @@ def test_auth_get_privileged_token(mocker):
     fake_privileged_token = create_mock_token(1600)
     fake_response = {"token": fake_privileged_token.token}
     vehicle_token_id = "1337"
+    permissions = [1, 2, 3, 4, 5]
 
     # Mock DIMO instance and token_exchange
     dimo_mock = Mock()
@@ -100,11 +101,36 @@ def test_auth_get_privileged_token(mocker):
     auth.access_token = create_mock_token(3600)
 
     # Test privileged token retrieval
-    privileged_token = auth.get_privileged_token(vehicle_token_id)
+    privileged_token = auth.get_privileged_token(vehicle_token_id, permissions)
 
     assert privileged_token.token == fake_privileged_token.token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
-        auth.access_token.token, privileges=[1, 2, 3, 4, 5], token_id=vehicle_token_id
+        auth.access_token.token,
+        privileges=permissions,
+        token_id=vehicle_token_id,
+    )
+
+
+def test_auth_get_privileged_token_without_permissions(mocker):
+    fake_privileged_token = create_mock_token(1600)
+    fake_response = {"token": fake_privileged_token.token}
+    vehicle_token_id = "1337"
+
+    # Mock DIMO instance and token_exchange
+    dimo_mock = Mock()
+    dimo_mock.token_exchange.exchange = Mock(return_value=fake_response)
+
+    auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
+    auth.access_token = create_mock_token(3600)
+
+    # Test privileged token retrieval
+    privileged_token = auth.get_privileged_token(vehicle_token_id, None)
+
+    assert privileged_token.token == fake_privileged_token.token
+    dimo_mock.token_exchange.exchange.assert_called_once_with(
+        auth.access_token.token,
+        privileges=[1, 2, 3, 4, 5, 6],
+        token_id=vehicle_token_id,
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.dimo.__init__ import DimoUpdateCoordinator, VehicleData
+from custom_components.dimo import DOMAIN
+
+
+@pytest.fixture
+def hass() -> HomeAssistant:
+    """Return a dummy HomeAssistant instance."""
+    return MagicMock(spec=HomeAssistant)
+
+
+@pytest.fixture
+def entry():
+    """Return a dummy config entry."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    # Populate the required data for the integration.
+    entry.data = {
+        "client_id": "dummy_client_id",
+        "auth_provider": "dummy_provider",
+        "private_key": "dummy_key",
+    }
+    return entry
+
+
+@pytest.fixture
+def client():
+    """Return a dummy DimoClient with a stubbed get_vin method."""
+    client = MagicMock()
+    client.get_vin = MagicMock(return_value="ABAH294120SJ1A21")
+    return client
+
+
+@pytest.fixture
+def coordinator(hass, entry, client):
+    """Return an instance of DimoUpdateCoordinator with a dummy vehicle in vehicle_data."""
+    coordinator = DimoUpdateCoordinator(hass, entry, client)
+    # Add dummy vehicle data with a known token ID.
+    vehicle_token_id = "41221"
+    coordinator.vehicle_data[vehicle_token_id] = VehicleData(
+        definition={"make": "TestMake", "model": "TestModel"}
+    )
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_vin_success(coordinator):
+    """Test that _get_vehicle_vin sets the VIN when get_api_data returns a VIN."""
+    vehicle_token_id = "41221"
+    expected_vin = "ABAH294120SJ1A21"
+    # Patch get_api_data to return a valid VIN.
+    with patch.object(
+        coordinator, "get_api_data", return_value=expected_vin
+    ) as mock_get_api_data:
+        await coordinator._get_vehicle_vin(vehicle_token_id)
+        # Verify that get_api_data was called with the client's get_vin and vehicle_token_id.
+        mock_get_api_data.assert_called_once_with(
+            coordinator.client.get_vin, vehicle_token_id
+        )
+        # Check that the VIN is stored on the vehicle data.
+        assert coordinator.vehicle_data[vehicle_token_id].vin == expected_vin
+
+
+def test_create_vehicle_device_with_vin(coordinator):
+    """Test create_vehicle_device for a vehicle with a VIN."""
+
+    vehicle_token_id = "41221"
+    vin_value = "ABAH294120SJ1A21"
+    # Set the VIN on the vehicle data.
+    vehicle = coordinator.vehicle_data[vehicle_token_id]
+    vehicle.vin = vin_value
+
+    # Create a dummy device registry object.
+    device_registry = MagicMock()
+
+    # Patch the device registry lookup used in create_vehicle_device.
+    with patch(
+        "custom_components.dimo.__init__.dr.async_get", return_value=device_registry
+    ) as mock_async_get:
+        coordinator.create_vehicle_device(vehicle_token_id)
+
+    # The expected identifiers should include both the token and the VIN.
+    expected_identifiers = {(DOMAIN, vehicle_token_id), (DOMAIN, vin_value)}
+    device_registry.async_get_or_create.assert_called_once_with(
+        config_entry_id=coordinator.entry.entry_id,
+        identifiers=expected_identifiers,
+        manufacturer=vehicle.definition["make"],
+        name=f'{vehicle.definition["make"]} {vehicle.definition["model"]}',
+        model=vehicle.definition["model"],
+    )


### PR DESCRIPTION
Since the VIN uniquely identifies the vehicle and never changes, it makes sense to include it as an identifier in the device info for a given vehicle.

Fixes #7
Fixes #126 