### PR TITLE
refactor: account for absence of signal data

### DIFF
--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -71,6 +71,9 @@ class DimoClient:
 
     def get_latest_signals(self, token_id, signal_names: list[str]):
         """Get the latest signal values for the specified vehicle"""
+        if signal_names is None:
+            signal_names = []
+            
         priv_token = self._fetch_privileged_token(token_id)
         signals_query = "\n".join(
             [


### PR DESCRIPTION
apparently, its possible for vehicles to lack any available signals. Hence we need to consider that before retrieving signal data.

Fixes #132