### PR TITLE
refactor: updated to Dimo SDK v1.3.0 and removed privilege retrieval

### DIFF
--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -44,9 +44,7 @@ class Auth:
         self.privileged_tokens: dict[str, AuthToken] = {}
         self.dimo = dimo if dimo else dimo_api.DIMO("Production")
 
-    def get_privileged_token(
-        self, vehicle_token_id: str, permissions: Optional[list]
-    ) -> AuthToken:
+    def get_privileged_token(self, vehicle_token_id: str) -> AuthToken:
         """Get privileged token from DIMO token exchange API"""
         if not self.privileged_tokens.get(
             vehicle_token_id

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -51,15 +51,9 @@ class Auth:
         if not self.privileged_tokens.get(
             vehicle_token_id
         ) or self._is_privileged_token_expired(vehicle_token_id):
-            if permissions is None:
-                _LOGGER.debug("No permissions specified. Fallback to default")
-                permissions = [1, 2, 3, 4, 5, 6]
-            _LOGGER.debug(
-                f"Obtaining privileged token for {vehicle_token_id} with privileges {permissions}"
-            )
+            _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
             token = self.dimo.token_exchange.exchange(
-                self.access_token.token,
-                privileges=permissions,
+                developer_jwt=self.access_token.token,
                 token_id=vehicle_token_id,
             )["token"]
 
@@ -87,7 +81,7 @@ class Auth:
     def _get_auth(self):
         _LOGGER.debug("Retrieving access token")
         try:
-            auth_header = self.dimo.auth.get_token(
+            auth_header = self.dimo.auth.get_dev_jwt(
                 client_id=self.client_id,
                 domain=self.domain,
                 private_key=self.private_key,

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -13,19 +13,10 @@ from .queries import (
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
-class VehicleSharingPermission:
-    """SACD permission model class"""
-
-    client_id: str
-    privileges: list
-
-
 class DimoClient:
-    def __init__(self, auth: Auth, permission_checker=None):
+    def __init__(self, auth: Auth):
         self.auth = auth
         self.dimo = auth.get_dimo()
-        self.permission_checker = permission_checker or self._check_sacd_permissions
 
     def init(self) -> None:
         """Initialize the client by retrieving an authorization token"""
@@ -41,10 +32,7 @@ class DimoClient:
             # Assert access token validity
             self.auth.get_access_token()
             # Get privileged token with the granted permissions
-            permissions = self.permission_checker(token_id)
-            return self.auth.get_privileged_token(
-                token_id, permissions.privileges
-            ).token
+            return self.auth.get_privileged_token(token_id).token
         except Exception as e:
             _LOGGER.error(f"Failed to obtain privileged token for {token_id}: {e}")
             raise
@@ -115,24 +103,6 @@ class DimoClient:
             _LOGGER.error(f"Failed to get total DIMO vehicles: {e}")
             return None
 
-    def _check_sacd_permissions(self, token_id) -> Optional[VehicleSharingPermission]:
-        """
-        Get Service Access Contract Definition details for a given vehicle,
-        including which clients the vehicle has been shared with and
-        with what permissions
-        """
-        result = self.dimo.identity.check_vehicle_privileges(token_id)
-        permissions_dict = result["data"]["vehicle"]["sacds"]["nodes"]
-
-        for perm in permissions_dict:
-            grantee = perm["grantee"]
-            if grantee == self.auth.client_id:
-                return VehicleSharingPermission(
-                    grantee, hex_to_permissions(perm["permissions"])
-                )
-
-        return None
-
     def get_vin(self, token_id) -> Optional[str]:
         """
         Retrieve the Vehicle Identification Number (VIN) for the specified token ID.
@@ -161,32 +131,3 @@ class DimoClient:
         except Exception as e:
             _LOGGER.error(f"Failed to retrieve VIN for token_id {token_id}: {e}")
             return None
-
-
-def hex_to_permissions(hex_value):
-    """
-    Convert a hex–encoded permission value into a list of permission levels.
-    """
-    num = int(hex_value, 0)
-    num >>= 2
-
-    bin_str = bin(num)[2:]
-
-    # Ensure an even number of bits by padding with a leading zero if needed.
-    if len(bin_str) % 2 != 0:
-        bin_str = "0" + bin_str
-
-    permissions = []
-    group_count = len(bin_str) // 2
-
-    # Process each group from right to left.
-    # The right–most group corresponds to permission level 1, the next to level 2, etc.
-    for i in range(group_count):
-        start = len(bin_str) - 2 * (i + 1)
-        end = len(bin_str) - 2 * i
-        group = bin_str[start:end]
-        # If the 2–bit group is nonzero, the permission is granted.
-        if int(group, 2) != 0:
-            permissions.append(i + 1)
-
-    return permissions

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -1,6 +1,4 @@
-from attr import dataclass
 import logging
-from dataclasses import dataclass
 from typing import Optional
 from .auth import Auth
 from .queries import (

--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
-    "dimo-python-sdk==1.2.0"
+    "dimo-python-sdk==1.3.0"
   ],
   "single_config_entry": true,
   "version": "0.5.2"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 coverage==7.6.8
-dimo-python-sdk==1.2.0
+dimo-python-sdk==1.3.0
 pytest-mock==3.14.0
 pytest-homeassistant-custom-component==0.13.201

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -20,14 +20,14 @@ def test_auth_get_token(mocker):
     # Mocking the DIMO instance and auth.get_token
     dimo_mock = Mock()
 
-    dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token.token})
+    dimo_mock.auth.get_dev_jwt = Mock(return_value={"access_token": fake_token.token})
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
 
     # Test token retrieval
     token = auth.get_access_token()
 
     assert token == fake_token
-    dimo_mock.auth.get_token.assert_called_once_with(
+    dimo_mock.auth.get_dev_jwt.assert_called_once_with(
         client_id="client_id", domain="domain", private_key="private_key"
     )
 
@@ -101,12 +101,11 @@ def test_auth_get_privileged_token(mocker):
     auth.access_token = create_mock_token(3600)
 
     # Test privileged token retrieval
-    privileged_token = auth.get_privileged_token(vehicle_token_id, permissions)
+    privileged_token = auth.get_privileged_token(vehicle_token_id)
 
     assert privileged_token.token == fake_privileged_token.token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
         auth.access_token.token,
-        privileges=permissions,
         token_id=vehicle_token_id,
     )
 
@@ -124,12 +123,11 @@ def test_auth_get_privileged_token_without_permissions(mocker):
     auth.access_token = create_mock_token(3600)
 
     # Test privileged token retrieval
-    privileged_token = auth.get_privileged_token(vehicle_token_id, None)
+    privileged_token = auth.get_privileged_token(vehicle_token_id)
 
     assert privileged_token.token == fake_privileged_token.token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
-        auth.access_token.token,
-        privileges=[1, 2, 3, 4, 5, 6],
+        developer_jwt=auth.access_token.token,
         token_id=vehicle_token_id,
     )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -75,14 +75,14 @@ def test_auth_get_dimo():
 def test_auth_get_token_calls_get_auth_when_token_is_none(mocker):
     fake_token = create_mock_token(3600)  # 1 hour from now
     dimo_mock = Mock()
-    dimo_mock.auth.get_token = Mock(return_value={"access_token": fake_token.token})
+    dimo_mock.auth.get_dev_jwt = Mock(return_value={"access_token": fake_token.token})
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
 
     token = auth.get_access_token()
 
     assert token == fake_token
-    dimo_mock.auth.get_token.assert_called_once_with(
+    dimo_mock.auth.get_dev_jwt.assert_called_once_with(
         client_id="client_id", domain="domain", private_key="private_key"
     )
 
@@ -91,7 +91,6 @@ def test_auth_get_privileged_token(mocker):
     fake_privileged_token = create_mock_token(1600)
     fake_response = {"token": fake_privileged_token.token}
     vehicle_token_id = "1337"
-    permissions = [1, 2, 3, 4, 5]
 
     # Mock DIMO instance and token_exchange
     dimo_mock = Mock()
@@ -105,7 +104,7 @@ def test_auth_get_privileged_token(mocker):
 
     assert privileged_token.token == fake_privileged_token.token
     dimo_mock.token_exchange.exchange.assert_called_once_with(
-        auth.access_token.token,
+        developer_jwt=auth.access_token.token,
         token_id=vehicle_token_id,
     )
 
@@ -142,7 +141,7 @@ def test_auth_get_privileged_token_without_permissions(mocker):
 )
 def test_auth_exceptions(mocker, mocked_exception, expected_exception):
     dimo_mock = Mock()
-    dimo_mock.auth.get_token = Mock(side_effect=mocked_exception)
+    dimo_mock.auth.get_dev_jwt = Mock(side_effect=mocked_exception)
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
 
@@ -179,7 +178,7 @@ def test_access_token_not_refreshed_if_not_expired(mocker):
     """Ensures we don't refresh the access token if it's still valid."""
     dimo_mock = Mock()
     # Make sure if we do fetch, it would be some placeholder
-    dimo_mock.auth.get_token = Mock(return_value={"access_token": "unused_new_token"})
+    dimo_mock.auth.get_dev_jwt = Mock(return_value={"access_token": "unused_new_token"})
 
     auth = Auth("client_id", "domain", "private_key", dimo=dimo_mock)
     valid_token = create_mock_token(3600)  # 1 hour from now
@@ -189,4 +188,4 @@ def test_access_token_not_refreshed_if_not_expired(mocker):
     token = auth.get_access_token()
 
     assert token == valid_token
-    dimo_mock.auth.get_token.assert_not_called()
+    dimo_mock.auth.get_dev_jwt.assert_not_called()

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -1,15 +1,6 @@
 from .helper import create_mock_token
 from unittest.mock import Mock
 from custom_components.dimo.dimoapi import DimoClient
-from custom_components.dimo.dimoapi.dimo_client import hex_to_permissions
-from custom_components.dimo.dimoapi.dimo_client import VehicleSharingPermission
-
-
-def dummy_permission_checker(token_id):
-    # Simulate a permission object for testing purposes.
-    return VehicleSharingPermission(
-        client_id="dummy_client", privileges=[1, 2, 3, 4, 5]
-    )
 
 
 def test_dimo_client_init():
@@ -70,10 +61,8 @@ def test_dimo_client_get_available_signals():
     priv_token = create_mock_token(3600)
     auth_mock.get_privileged_token.return_value = priv_token
 
+    dimo_client = DimoClient(auth=auth_mock)
     token_id = "vehicle123"
-    dimo_client = DimoClient(
-        auth=auth_mock, permission_checker=dummy_permission_checker
-    )
     query_result = {"availableSignals": []}
     dimo_mock.telemetry.query.return_value = query_result
 
@@ -89,9 +78,7 @@ query AvailableSignals {{
 """,
         priv_token.token,
     )
-    auth_mock.get_privileged_token.assert_called_once_with(
-        token_id, dummy_permission_checker(token_id).privileges
-    )
+    auth_mock.get_privileged_token.assert_called_once_with(token_id)
 
 
 def test_dimo_client_get_latest_signals():
@@ -100,9 +87,7 @@ def test_dimo_client_get_latest_signals():
     priv_token = create_mock_token(3600)
     auth_mock.get_privileged_token.return_value = priv_token
 
-    dimo_client = DimoClient(
-        auth=auth_mock, permission_checker=dummy_permission_checker
-    )
+    dimo_client = DimoClient(auth=auth_mock)
     dimo_client.dimo = dimo_mock  # Inject the dimo mock
 
     token_id = "123"
@@ -144,18 +129,14 @@ def test_dimo_client_get_latest_signals():
 
     # Ensure privileged token was used
     dimo_mock.telemetry.query.assert_called_once_with(actual_query, priv_token.token)
-    auth_mock.get_privileged_token.assert_called_once_with(
-        token_id, dummy_permission_checker(token_id).privileges
-    )
+    auth_mock.get_privileged_token.assert_called_once_with(token_id)
 
 
 def test_dimo_client_get_vin_success():
     # Arrange: Set up mocks
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
-    dimo_client = DimoClient(
-        auth=auth_mock, permission_checker=dummy_permission_checker
-    )
+    dimo_client = DimoClient(auth=auth_mock)
     token_id = "vehicle123"
 
     # Mock the privileged token and VIN response
@@ -170,9 +151,7 @@ def test_dimo_client_get_vin_success():
 
     # Assert: Verify the results and interactions
     assert vin == "1HGCM82633A123456"
-    auth_mock.get_privileged_token.assert_called_once_with(
-        token_id, dummy_permission_checker(token_id).privileges
-    )
+    auth_mock.get_privileged_token.assert_called_once_with(token_id)
     dimo_mock.telemetry.get_vin.assert_called_once_with(mocked_token.token, token_id)
 
 
@@ -180,9 +159,7 @@ def test_dimo_client_get_vin_malformed_response():
     # Arrange: Set up mocks
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
-    dimo_client = DimoClient(
-        auth=auth_mock, permission_checker=dummy_permission_checker
-    )
+    dimo_client = DimoClient(auth=auth_mock)
     token_id = "vehicle123"
 
     # Mock the privileged token and malformed response
@@ -195,9 +172,7 @@ def test_dimo_client_get_vin_malformed_response():
 
     # Assert: Verify the results and interactions
     assert vin is None
-    auth_mock.get_privileged_token.assert_called_once_with(
-        token_id, dummy_permission_checker(token_id).privileges
-    )
+    auth_mock.get_privileged_token.assert_called_once_with(token_id)
     dimo_mock.telemetry.get_vin.assert_called_once_with(mocked_token.token, token_id)
 
 
@@ -227,15 +202,3 @@ def test_dimo_client_get_total_dimo_vehicles_exception():
 
     assert total_vehicles is None
     dimo_mock.identity.count_dimo_vehicles.assert_called_once()
-
-
-def test_dimo_client_hex_to_permissions():
-    permissions_hex = "0x3ffc"
-    permissions_list = hex_to_permissions(permissions_hex)
-    assert permissions_list == [1, 2, 3, 4, 5, 6]
-
-    one_to_five_hex = "0xffc"
-    assert hex_to_permissions(one_to_five_hex) == [1, 2, 3, 4, 5]
-
-    another_hex = "0x3fcc"
-    assert hex_to_permissions(another_hex) == [1, 3, 4, 5, 6]


### PR DESCRIPTION
The new version of the DIMO SDK v.1.3.0 includes privilege level retrieval so we can remove this mechanism from the integration code. There are also some renaming of methods, etc. 

Fixes #157 