### PR TITLE
refactor(dimoapi): migrate to new SDK available_signals method

### DIFF
--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -3,7 +3,6 @@ from typing import Optional
 from .auth import Auth
 from .queries import (
     GET_VEHICLE_REWARDS_QUERY,
-    GET_AVAILABLE_SIGNALS_QUERY,
     GET_LATEST_SIGNALS_QUERY,
     GET_ALL_VEHICLES_QUERY,
 )
@@ -54,8 +53,7 @@ class DimoClient:
     def get_available_signals(self, token_id: str):
         """Get list of available signals for a specified vehicle"""
         priv_token = self._fetch_privileged_token(token_id)
-        query = GET_AVAILABLE_SIGNALS_QUERY.format(token_id=token_id)
-        return self.dimo.telemetry.query(query, priv_token)
+        return self.dimo.telemetry.available_signals(priv_token, token_id)
 
     def get_latest_signals(self, token_id, signal_names: list[str]):
         """Get the latest signal values for the specified vehicle"""

--- a/custom_components/dimo/dimoapi/queries.py
+++ b/custom_components/dimo/dimoapi/queries.py
@@ -8,12 +8,6 @@ query GetVehicleRewardsByTokenId {{
 }}
 """
 
-GET_AVAILABLE_SIGNALS_QUERY = """
-query AvailableSignals {{
-  availableSignals(tokenId: {token_id})
-}}
-"""
-
 GET_LATEST_SIGNALS_QUERY = """
 query {{
   signalsLatest(tokenId: {token_id}) {{

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -64,19 +64,15 @@ def test_dimo_client_get_available_signals():
     dimo_client = DimoClient(auth=auth_mock)
     token_id = "vehicle123"
     query_result = {"availableSignals": []}
-    dimo_mock.telemetry.query.return_value = query_result
+    dimo_mock.telemetry.available_signals.return_value = query_result
 
     result = dimo_client.get_available_signals(token_id)
 
     # Assert the result and query
     assert result == query_result
-    dimo_mock.telemetry.query.assert_called_once_with(
-        f"""
-query AvailableSignals {{
-  availableSignals(tokenId: {token_id})
-}}
-""",
+    dimo_mock.telemetry.available_signals.assert_called_once_with(
         priv_token.token,
+        token_id,
     )
     auth_mock.get_privileged_token.assert_called_once_with(token_id)
 


### PR DESCRIPTION
The DIMO SDK now contains a helper method to retrieve available signals for a given `token_id`, which is implements the exact same query as this integration does. We can therefore do a drop-in replacement, saving us some lines of code and potential maintenance load down the road.