### PR TITLE
refactor: assert that signal data is available before adding token re…

### DIFF
--- a/custom_components/dimo/__init__.py
+++ b/custom_components/dimo/__init__.py
@@ -255,10 +255,11 @@ class DimoUpdateCoordinator(DataUpdateCoordinator):
             if rewards_data:
                 timestamp = self._get_current_timestamp()
                 earnings = rewards_data["data"]["vehicle"]["earnings"]["totalTokens"]
-                self.vehicle_data[vehicle_token_id].signal_data["tokenRewards"] = {
-                    "timestamp": timestamp,
-                    "value": earnings,
-                }
+                if self.vehicle_data[vehicle_token_id].signal_data:
+                    self.vehicle_data[vehicle_token_id].signal_data["tokenRewards"] = {
+                        "timestamp": timestamp,
+                        "value": earnings,
+                    }
         except KeyError:
             _LOGGER.warning(
                 "Rewards data structure unexpected for vehicle %s.", vehicle_token_id


### PR DESCRIPTION
…wards.

if the DIMO api fails to return signal data, the associated data dictionary is not initialized and hence we get an error when trying to append token rewards data. Instead we should assert that signal data has indeed been initialized first.

References #153