### PR TITLE
refactor: make DimoVehicleBinarySensorEntity guard against None entries.

### DIFF
--- a/custom_components/dimo/binary_sensor.py
+++ b/custom_components/dimo/binary_sensor.py
@@ -64,8 +64,12 @@ class DimoVehicleBinarySensorEntity(DimoBaseVehicleEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return (
-            self.coordinator.vehicle_data[self.vehicle_token_id]
-            .signal_data[self.key]
-            .get("value")
-        )
+        vehicle = self.coordinator.vehicle_data.get(self.vehicle_token_id)
+        if vehicle is None:
+            return None
+
+        signal = vehicle.signal_data.get(self.key)
+        if not signal or "value" not in signal:
+            return None
+
+        return signal.get("value")

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,74 @@
+import pytest
+from types import SimpleNamespace
+
+from custom_components.dimo.binary_sensor import DimoVehicleBinarySensorEntity
+
+
+class DummyCoordinator:
+    """A minimal stub for DimoUpdateCoordinator holding vehicle_data."""
+
+    def __init__(self, vehicle_data, domain: str = "dimo"):
+        self.vehicle_data = vehicle_data
+        self.entry = SimpleNamespace(domain=domain)
+
+
+def make_entity(coordinator, token, key):
+    """Helper to construct the sensor entity."""
+    return DimoVehicleBinarySensorEntity(coordinator, token, key)
+
+
+def test_is_on_true():
+    """When signal_data contains a truthy value, is_on returns True."""
+    token = "123456"
+    key = "currentLocationIsRedacted"
+
+    vehicle = SimpleNamespace(signal_data={key: {"value": True}})
+    coord = DummyCoordinator({token: vehicle})
+
+    entity = make_entity(coord, token, key)
+    assert entity.is_on is True
+
+
+def test_is_on_false():
+    """When signal_data contains a falsy value (False), is_on returns False."""
+    token = "123456"
+    key = "currentLocationIsRedacted"
+    vehicle = SimpleNamespace(signal_data={key: {"value": False}})
+    coord = DummyCoordinator({token: vehicle})
+
+    entity = make_entity(coord, token, key)
+    assert entity.is_on is False
+
+
+def test_is_on_missing_signal_key():
+    """When signal_data lacks the key, is_on returns None (unavailable)."""
+    token = "1234566"
+    key = "currentLocationIsRedacted"
+    vehicle = SimpleNamespace(signal_data={})
+    coord = DummyCoordinator({token: vehicle})
+
+    entity = make_entity(coord, token, key)
+    assert entity.is_on is None
+
+
+def test_is_on_signal_none():
+    """When signal_data[key] is None, is_on returns None without exception."""
+    token = "12345676"
+    key = "currentLocationIsRedacted"
+    vehicle = SimpleNamespace(signal_data={key: None})
+    coord = DummyCoordinator({token: vehicle})
+
+    entity = make_entity(coord, token, key)
+    assert entity.is_on is None
+
+
+def test_is_on_missing_vehicle():
+    """When the vehicle_token_id is not present, is_on returns None."""
+    token = "123450900"
+    key = "currentLocationIsRedacted"
+    # coordinator has data for a different token
+    other_vehicle = SimpleNamespace(signal_data={key: {"value": True}})
+    coord = DummyCoordinator({"111222": other_vehicle})
+
+    entity = make_entity(coord, token, key)
+    assert entity.is_on is None


### PR DESCRIPTION
makes sure we never call ``.get()`` on None and instead bubble up None to Home Assistant, which it interprets as “unavailable”.

Fixes #182