### PR TITLE
fix: updated dimo sdk for content-type checking fix

### DIFF
--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
-    "dimo-python-sdk==1.3.3"
+    "dimo-python-sdk==1.3.5"
   ],
   "single_config_entry": true,
   "version": "0.7.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 coverage==7.6.8
-dimo-python-sdk==1.3.3
+dimo-python-sdk==1.3.5
 pytest-mock==3.14.0
 pytest-homeassistant-custom-component==0.13.201


### PR DESCRIPTION
The DIMO Python SDK was recently updated with more robust, but stricted response checks in order to
provide correctly decoded response data.

This worked fine at the time when v0.7.0 of the HA integration was published, but yesterday the DIMO API was updated and now requests return a different content type.

This caused returned data to not be json decoded which is what broke the Home Assistant integration

The DIMO Python SDK has now been updated with a refactored content type check.

Fixes #185