### PR TITLE
fix: assert that a token is actually returned during exchange.

### DIFF
--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -83,7 +83,7 @@ class Auth:
 
             token = result.get("token")
             if not token:
-                raise ValueError("Token exchange did not return a token")
+                raise ValueError(f"Token exchange failed for {vehicle_token_id}, response: {result}")
 
             self.privileged_tokens[vehicle_token_id] = AuthToken(token)
 

--- a/custom_components/dimo/dimoapi/auth.py
+++ b/custom_components/dimo/dimoapi/auth.py
@@ -76,10 +76,14 @@ class Auth:
         token = self.privileged_tokens.get(vehicle_token_id)
         if token is None or token.is_expired():
             _LOGGER.debug(f"Obtaining privileged token for {vehicle_token_id}")
-            token = self.dimo.token_exchange.exchange(
+            result = self.dimo.token_exchange.exchange(
                 developer_jwt=self.access_token.token,
                 token_id=vehicle_token_id,
-            )["token"]
+            )
+
+            token = result.get("token")
+            if not token:
+                raise ValueError("Token exchange did not return a token")
 
             self.privileged_tokens[vehicle_token_id] = AuthToken(token)
 


### PR DESCRIPTION
we shouldnt assume that a `token` value is always included in the response and handle its absence properly.