### PR TITLE
refactor: implemented chunked signals retrieval

### DIFF
--- a/custom_components/dimo/__init__.py
+++ b/custom_components/dimo/__init__.py
@@ -205,7 +205,7 @@ class DimoUpdateCoordinator(DataUpdateCoordinator):
         """Get data for list of available signals for vehicle."""
         if self.vehicle_data.get(vehicle_token_id):
             signals_data = await self.get_api_data(
-                self.client.get_latest_signals,
+                self.client.get_latest_signals_batched,
                 vehicle_token_id,
                 self.vehicle_data[vehicle_token_id].available_signals,
             )

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -122,7 +122,7 @@ class DimoClient:
             return False
         for e in errs:
             code = (e.get("extensions", {}).get("code") or "").upper()
-            if code in {"COMPLEXITY_LIMIT_EXCEEDED"}:
+            if code == "COMPLEXITY_LIMIT_EXCEEDED":
                 return True
         return False
 

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -71,16 +71,6 @@ class DimoClient:
         return self.dimo.telemetry.available_signals(vehicle_jwt, token_id)
 
     @staticmethod
-    def _chunked(iterable: Iterable[str], n: int) -> Iterable[list[str]]:
-        """Yield successive chunks (lists) of size n from iterable."""
-        it = iter(iterable)
-        while True:
-            chunk = list(islice(it, n))
-            if not chunk:
-                return
-            yield chunk
-
-    @staticmethod
     def _merge_graphql_data(responses: list[dict]) -> dict:
         """
         Merge multiple GraphQL responses for signalsLatest:

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -151,7 +151,7 @@ class DimoClient:
         Returns a combined GraphQL-style response dict.
         """
         if not signal_names:
-            return {"data": {}}
+            return {"data": {"signalsLatest": {}}}
 
         chunk_size = max(initial_chunk_size, min_chunk_size)
         merged_responses: List[Dict[str, Any]] = []

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -1,7 +1,8 @@
 import requests
 import logging
+from itertools import islice
 from functools import wraps
-from typing import Optional
+from typing import Optional, Iterable, Dict, Any, List
 from .auth import Auth
 from .queries import (
     GET_VEHICLE_REWARDS_QUERY,
@@ -11,13 +12,17 @@ from .queries import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def requires_vehicle_jwt(method):
     """Decorator that fetches vehicle jwt and unpacks token into call"""
+
     @wraps(method)
     def wrapper(self, token_id: str, *args, **kwargs):
         vehicle_jwt = self._fetch_privileged_token(token_id)
         return method(self, vehicle_jwt, token_id, *args, **kwargs)
+
     return wrapper
+
 
 class DimoClient:
     def __init__(self, auth: Auth):
@@ -35,7 +40,7 @@ class DimoClient:
     def _fetch_privileged_token(self, token_id: str) -> str:
         """Retrieve privileged token for specified token id"""
         try:
-            self.auth.get_access_token() 
+            self.auth.get_access_token()
             return self.auth.get_privileged_token(token_id).token
         except Exception as e:
             _LOGGER.error(f"Failed to obtain privileged token for {token_id}: {e}")
@@ -65,23 +70,161 @@ class DimoClient:
         """Get list of available signals for a specified vehicle"""
         return self.dimo.telemetry.available_signals(vehicle_jwt, token_id)
 
-    @requires_vehicle_jwt
-    def get_latest_signals(self, vehicle_jwt: str, token_id: str, signal_names: Optional[list[str]]):
-        """Get the latest signal values for the specified vehicle"""
+    @staticmethod
+    def _chunked(iterable: Iterable[str], n: int) -> Iterable[list[str]]:
+        """Yield successive chunks (lists) of size n from iterable."""
+        it = iter(iterable)
+        while True:
+            chunk = list(islice(it, n))
+            if not chunk:
+                return
+            yield chunk
+
+    @staticmethod
+    def _merge_graphql_data(responses: list[dict]) -> dict:
+        """
+        Merge multiple GraphQL responses for signalsLatest:
+          {"data": {"signalsLatest": {...}}, "errors":[...]}
+        into one combined response.
+        """
+        merged: dict = {"data": {"signalsLatest": {}}}
+        errors: list = []
+
+        for r in responses or []:
+            if not isinstance(r, dict):
+                continue
+
+            # Merge data.signalsLatest
+            data = r.get("data", {})
+            if isinstance(data, dict):
+                sl = data.get("signalsLatest", {})
+                if isinstance(sl, dict):
+                    # add/override per-signal fields; different chunks add different keys
+                    merged["data"]["signalsLatest"].update(sl)
+
+            # Carry over GraphQL errors
+            if isinstance(r.get("errors"), list):
+                errors.extend(r["errors"])
+
+        if errors:
+            merged["errors"] = errors
+        return merged
+
+    @staticmethod
+    def _is_complexity_error(resp: Dict[str, Any]) -> bool:
+        """
+        Return True if the GraphQL response includes a complexity/validation error.
+        This checks common shapes like:
+          {"errors":[{"message":"query is too complex", "extensions":{"code":"COMPLEXITY_LIMIT_EXCEEDED"}}]}
+        """
+        errs = resp.get("errors")
+        if not isinstance(errs, list):
+            return False
+        for e in errs:
+            code = (e.get("extensions", {}).get("code") or "").upper()
+            if code in {"COMPLEXITY_LIMIT_EXCEEDED"}:
+                return True
+        return False
+
+    def _build_latest_signals_query(
+        self, token_id: str, signal_names: list[str]
+    ) -> str:
+        """Build the GraphQL query body for the provided signal names."""
         signals_query = "\n".join(
-            [
-                f"{signal_name} {{\n  timestamp\n  value\n}}"
-                for signal_name in (signal_names or [])
-            ]
+            f"{name} {{\n  timestamp\n  value\n}}" for name in signal_names
         )
-        query = GET_LATEST_SIGNALS_QUERY.format(
-            token_id=token_id, signals=signals_query
-        )
-        return self.dimo.telemetry.query(query, vehicle_jwt)
+        return GET_LATEST_SIGNALS_QUERY.format(token_id=token_id, signals=signals_query)
+
+    @requires_vehicle_jwt
+    def get_latest_signals_batched(
+        self,
+        vehicle_jwt: str,
+        token_id: str,
+        signal_names: list[str],
+        *,
+        initial_chunk_size: int = 25,
+        min_chunk_size: int = 5,
+    ) -> Dict[str, Any]:
+        """
+        Fetch latest signals in multiple sub-queries to avoid GraphQL complexity limits.
+
+        Returns a combined GraphQL-style response dict.
+        """
+        if not signal_names:
+            return {"data": {}}
+
+        chunk_size = max(initial_chunk_size, min_chunk_size)
+        merged_responses: List[Dict[str, Any]] = []
+
+        i = 0
+        total = len(signal_names)
+        while i < total:
+            # dynamically size the chunk window
+            end = min(i + chunk_size, total)
+            chunk = signal_names[i:end]
+            query = self._build_latest_signals_query(token_id, chunk)
+
+            while True:
+                try:
+                    _LOGGER.debug(
+                        "Querying signals %d..%d (size=%d): %s",
+                        i,
+                        end - 1,
+                        len(chunk),
+                        ", ".join(chunk),
+                    )
+                    resp = self.dimo.telemetry.query(query, vehicle_jwt)
+
+                    if self._is_complexity_error(resp):
+                        # reduce chunk size and retry this window
+                        if chunk_size <= min_chunk_size:
+                            _LOGGER.error(
+                                "Complexity limit even at min_chunk_size=%d (signals %d..%d).",
+                                min_chunk_size,
+                                i,
+                                end - 1,
+                            )
+                            # surface the server error rather than hiding it
+                            raise RuntimeError(
+                                "GraphQL complexity limit exceeded at minimum chunk size"
+                            )
+
+                        chunk_size = max(min_chunk_size, chunk_size // 2)
+                        _LOGGER.warning(
+                            "Complexity hit. Reducing chunk_size to %d and retrying signals %d..%d.",
+                            chunk_size,
+                            i,
+                            end - 1,
+                        )
+                        # recompute chunk boundaries with smaller chunk size
+                        end = min(i + chunk_size, total)
+                        chunk = signal_names[i:end]
+                        query = self._build_latest_signals_query(token_id, chunk)
+                        continue
+
+                    # success path
+                    merged_responses.append(resp)
+                    break
+
+                except Exception as e:
+                    # Unknown error: propagate so caller can decide
+                    _LOGGER.error(
+                        "Unexpected error querying signals %d..%d: %s", i, end - 1, e
+                    )
+                    raise
+
+            # advance window
+            i = end
+
+        # merge all chunk results into one GraphQL-like response
+        combined = self._merge_graphql_data(merged_responses)
+        return combined
 
     def get_all_vehicles_for_license(self, license_id=None):
         """List all vehicles for the specified license."""
-        query = GET_ALL_VEHICLES_QUERY.format(license_id=license_id or self.auth.client_id)
+        query = GET_ALL_VEHICLES_QUERY.format(
+            license_id=license_id or self.auth.client_id
+        )
         return self.dimo.identity.query(query)
 
     def get_total_dimo_vehicles(self) -> Optional[int]:
@@ -90,7 +233,9 @@ class DimoClient:
             result = self.dimo.identity.count_dimo_vehicles()
             return result.get("data", {}).get("vehicles", {}).get("totalCount")
         except requests.exceptions.ConnectionError as ex:
-            _LOGGER.warning("DIMO API request error when retrieving DIMO vehicle count: %s", ex)
+            _LOGGER.warning(
+                "DIMO API request error when retrieving DIMO vehicle count: %s", ex
+            )
             return None
         except Exception as e:
             _LOGGER.error(f"Failed to get total DIMO vehicles: {e}")
@@ -103,15 +248,25 @@ class DimoClient:
             vin_response = self.dimo.telemetry.get_vin(vehicle_jwt, token_id)
             vin = vin_response.get("data", {}).get("vinVCLatest", {}).get("vin")
             if vin:
-                _LOGGER.debug(f"Successfully retrieved VIN for token_id {token_id}: {vin}")
+                _LOGGER.debug(
+                    f"Successfully retrieved VIN for token_id {token_id}: {vin}"
+                )
                 return vin
-            _LOGGER.warning(f"VIN not found in response for token_id {token_id}: {vin_response}")
+            _LOGGER.warning(
+                f"VIN not found in response for token_id {token_id}: {vin_response}"
+            )
             return None
         except KeyError as e:
-            _LOGGER.error(f"Malformed response when retrieving VIN for token_id {token_id}: {e}")
+            _LOGGER.error(
+                f"Malformed response when retrieving VIN for token_id {token_id}: {e}"
+            )
             return None
         except requests.exceptions.ConnectionError as ex:
-            _LOGGER.warning("Connection error occurred while retrieving VIN for token id %s: %s", token_id, ex)
+            _LOGGER.warning(
+                "Connection error occurred while retrieving VIN for token id %s: %s",
+                token_id,
+                ex,
+            )
             return None
         except Exception as e:
             _LOGGER.error(f"Failed to retrieve VIN for token_id {token_id}: {e}")

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -33,7 +33,7 @@ def test_dimo_client_get_rewards_for_vehicle():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle123"
+    token_id = "75948"
 
     # Mock the GraphQL query result
     query_result = {"data": {"vehicle": {"earnings": {"totalTokens": 100.5}}}}
@@ -62,7 +62,7 @@ def test_dimo_client_get_available_signals():
     auth_mock.get_privileged_token.return_value = priv_token
 
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle123"
+    token_id = "75123"
     query_result = {"availableSignals": []}
     dimo_mock.telemetry.available_signals.return_value = query_result
 
@@ -86,7 +86,7 @@ def test_dimo_client_get_latest_signals():
     dimo_client = DimoClient(auth=auth_mock)
     dimo_client.dimo = dimo_mock  # Inject the dimo mock
 
-    token_id = "123"
+    token_id = "88888"
     signal_names = [
         "chassisAxleRow1WheelLeftTirePressure",
         "chassisAxleRow1WheelRightTirePressure",
@@ -229,7 +229,7 @@ def test_dimo_client_get_latest_signals():
                     },
                     "speed": {"timestamp": "2025-08-08T18:48:44Z", "value": 0},
                 },
-            }
+            },
         }
     }
     dimo_mock.telemetry.query.return_value = query_result
@@ -253,7 +253,7 @@ def test_dimo_client_get_latest_signals_batched_empty():
     dimo_client = DimoClient(auth=auth_mock)
     dimo_client.dimo = dimo_mock  # Inject the dimo mock
 
-    token_id = "123"
+    token_id = "777"
     signal_names = []  # Empty signal names
 
     # Call the method under test
@@ -272,7 +272,7 @@ def test_dimo_client_get_latest_signals_batched_normal():
     dimo_client = DimoClient(auth=auth_mock)
     dimo_client.dimo = dimo_mock  # Inject the dimo mock
 
-    token_id = "123"
+    token_id = "90019"
     signal_names = ["signal1", "signal2", "signal3"]
     query_result = {
         "data": {
@@ -302,7 +302,7 @@ def test_dimo_client_get_latest_signals_batched_complexity_error():
     dimo_client = DimoClient(auth=auth_mock)
     dimo_client.dimo = dimo_mock  # Inject the dimo mock
 
-    token_id = "123"
+    token_id = "88001"
     signal_names = [f"signal{i}" for i in range(50)]  # Large number of signals to test chunking
 
     def complexity_error_simulation(query, vehicle_jwt):
@@ -318,12 +318,11 @@ def test_dimo_client_get_latest_signals_batched_complexity_error():
         assert str(e) == "GraphQL complexity limit exceeded at minimum chunk size"
 
 
-
     # Arrange: Set up mocks
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle123"
+    token_id = "18003"
 
     # Mock the privileged token and VIN response
     mocked_token = create_mock_token(3600)
@@ -346,7 +345,7 @@ def test_dimo_client_get_vin_malformed_response():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle123"
+    token_id = "65999"
 
     # Mock the privileged token and malformed response
     mocked_token = create_mock_token(1200)
@@ -395,7 +394,7 @@ def test_dimo_client_lock_doors():
     priv_token = create_mock_token(600)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle-lock"
+    token_id = "99994"
     dimo_mock.devices.lock_doors.return_value = {"result": "locked"}
     result = dimo_client.lock_doors(token_id)
     assert result == {"result": "locked"}
@@ -408,7 +407,7 @@ def test_dimo_client_unlock_doors():
     priv_token = create_mock_token(600)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle-unlock"
+    token_id = "99995"
     dimo_mock.devices.unlock_doors.return_value = {"result": "unlocked"}
     result = dimo_client.unlock_doors(token_id)
     assert result == {"result": "unlocked"}
@@ -420,7 +419,7 @@ def test_fetch_privileged_token_success():
     priv_token = create_mock_token(1200)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "mytoken"
+    token_id = "10234"
     # Patch auth.get_access_token to do nothing
     auth_mock.get_access_token.return_value = None
     result = dimo_client._fetch_privileged_token(token_id)
@@ -432,7 +431,7 @@ def test_fetch_privileged_token_exception():
     auth_mock = Mock()
     auth_mock.get_privileged_token.side_effect = Exception("fail")
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "errortoken"
+    token_id = "20345"
     auth_mock.get_access_token.return_value = None
     try:
         dimo_client._fetch_privileged_token(token_id)
@@ -446,22 +445,23 @@ def test_get_all_vehicles_for_license_default():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    auth_mock.client_id = "ABC123"
+    auth_mock.client_id = "0xd9E311344F1eFA490C82615d3989687A5628afb4"
     dimo_mock.identity.query.return_value = {"vehicles": [1, 2, 3]}
     result = dimo_client.get_all_vehicles_for_license()
     assert result == {"vehicles": [1, 2, 3]}
     dimo_mock.identity.query.assert_called_once()
-    assert 'privileged: "ABC123"' in dimo_mock.identity.query.call_args[0][0]
+    assert 'privileged: "0xd9E311344F1eFA490C82615d3989687A5628afb4"' in dimo_mock.identity.query.call_args[0][0]
 
 def test_get_all_vehicles_for_license_with_arg():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
     dimo_mock.identity.query.return_value = {"vehicles": [42]}
-    result = dimo_client.get_all_vehicles_for_license("licenseZ")
+    license_addr = "0xAbCdEf789012345678901234567890abcdef1234"
+    result = dimo_client.get_all_vehicles_for_license(license_addr)
     assert result == {"vehicles": [42]}
     dimo_mock.identity.query.assert_called_once()
-    assert 'privileged: "licenseZ"' in dimo_mock.identity.query.call_args[0][0]
+    assert f'privileged: "{license_addr}"' in dimo_mock.identity.query.call_args[0][0]
 
 def test_merge_graphql_data_merges_responses():
     responses = [
@@ -488,7 +488,7 @@ def test_dimo_client_get_vin_keyerror():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle-fake"
+    token_id = "82111"
     priv_token = create_mock_token(10)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_mock.telemetry.get_vin.side_effect = KeyError("failkey")
@@ -502,7 +502,7 @@ def test_dimo_client_get_vin_connection_error():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle-timeout"
+    token_id = "73103"
     priv_token = create_mock_token(23)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_mock.telemetry.get_vin.side_effect = requests.exceptions.ConnectionError("test")
@@ -515,7 +515,7 @@ def test_dimo_client_get_vin_general_exception():
     auth_mock = Mock()
     dimo_mock = auth_mock.get_dimo.return_value
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle-ex"
+    token_id = "82102"
     priv_token = create_mock_token(23)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_mock.telemetry.get_vin.side_effect = Exception("ohno")
@@ -531,7 +531,7 @@ def test_get_latest_signals_batched_unknown_exception():
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_client = DimoClient(auth=auth_mock)
     dimo_client.dimo = dimo_mock
-    token_id = "tok"
+    token_id = "56777"
     signal_names = ["sig1", "sig2"]
     # Simulate unknown exception in telemetry.query
     def raise_exc(*a, **kw):
@@ -550,7 +550,7 @@ def test_get_latest_signals_batched_unknown_exception():
     auth_mock = Mock()
     auth_mock.get_privileged_token.side_effect = Exception("fail")
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "errortoken"
+    token_id = "55555"
     auth_mock.get_access_token.return_value = None
     try:
         dimo_client._fetch_privileged_token(token_id)
@@ -565,7 +565,7 @@ def test_get_latest_signals_batched_unknown_exception():
     priv_token = create_mock_token(600)
     auth_mock.get_privileged_token.return_value = priv_token
     dimo_client = DimoClient(auth=auth_mock)
-    token_id = "vehicle-unlock"
+    token_id = "58585"
     dimo_mock.devices.unlock_doors.return_value = {"result": "unlocked"}
     result = dimo_client.unlock_doors(token_id)
     assert result == {"result": "unlocked"}

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -87,12 +87,148 @@ def test_dimo_client_get_latest_signals():
     dimo_client.dimo = dimo_mock  # Inject the dimo mock
 
     token_id = "123"
-    signal_names = ["speed", "batteryLevel"]
+    signal_names = [
+        "chassisAxleRow1WheelLeftTirePressure",
+        "chassisAxleRow1WheelRightTirePressure",
+        "chassisAxleRow2WheelLeftTirePressure",
+        "chassisAxleRow2WheelRightTirePressure",
+        "currentLocationAltitude",
+        "currentLocationHeading",
+        "currentLocationIsRedacted",
+        "currentLocationLatitude",
+        "currentLocationLongitude",
+        "dimoAftermarketHDOP",
+        "dimoAftermarketNSAT",
+        "exteriorAirTemperature",
+        "lowVoltageBatteryCurrentVoltage",
+        "obdBarometricPressure",
+        "obdDTCList",
+        "obdDistanceWithMIL",
+        "obdEngineLoad",
+        "obdIntakeTemp",
+        "obdMAP",
+        "obdRunTime",
+        "obdStatusDTCCount",
+        "powertrainCombustionEngineECT",
+        "powertrainCombustionEngineMAF",
+        "powertrainCombustionEngineSpeed",
+        "powertrainCombustionEngineTPS",
+        "powertrainFuelSystemAbsoluteLevel",
+        "powertrainFuelSystemRelativeLevel",
+        "powertrainRange",
+        "powertrainTractionBatteryChargingIsCharging",
+        "powertrainTractionBatteryRange",
+        "powertrainTractionBatteryStateOfChargeCurrent",
+        "powertrainTransmissionTravelledDistance",
+        "powertrainType",
+        "speed",
+    ]
     query_result = {
         "data": {
             "signalsLatest": {
-                "speed": {"timestamp": "2024-11-27T12:00:00Z", "value": 60},
-                "batteryLevel": {"timestamp": "2024-11-27T12:00:00Z", "value": 80},
+                "chassisAxleRow1WheelLeftTirePressure": {
+                    "timestamp": "2024-07-19T16:45:16.517921Z",
+                    "value": 252.5,
+                },
+                "chassisAxleRow1WheelRightTirePressure": {
+                    "timestamp": "2024-07-19T16:45:16.517921Z",
+                    "value": 255.2,
+                },
+                "chassisAxleRow2WheelLeftTirePressure": {
+                    "timestamp": "2024-07-19T16:45:16.517921Z",
+                    "value": 293.7,
+                },
+                "chassisAxleRow2WheelRightTirePressure": {
+                    "timestamp": "2024-07-19T16:45:16.517921Z",
+                    "value": 296.4,
+                },
+                "dimoAftermarketHDOP": {
+                    "timestamp": "2025-08-08T18:48:44Z",
+                    "value": 0.8,
+                },
+                "dimoAftermarketNSAT": {
+                    "timestamp": "2025-08-08T18:48:44Z",
+                    "value": 22,
+                },
+                "exteriorAirTemperature": {
+                    "timestamp": "2025-08-08T18:48:44Z",
+                    "value": 18,
+                },
+                "lowVoltageBatteryCurrentVoltage": {
+                    "timestamp": "2025-08-08T18:48:44Z",
+                    "value": 12.786,
+                },
+                "obdBarometricPressure": {
+                    "timestamp": "2024-12-02T07:25:42Z",
+                    "value": 99,
+                },
+                "obdDTCList": {
+                    "timestamp": "2025-08-08T18:48:47Z",
+                    "obdDistanceWithMIL": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": 0,
+                    },
+                    "obdEngineLoad": {
+                        "timestamp": "2024-11-28T19:13:38Z",
+                        "value": 0.071,
+                    },
+                    "obdIntakeTemp": {"timestamp": "2024-12-02T07:28:11Z", "value": 18},
+                    "obdMAP": {"timestamp": "2024-12-02T07:28:11Z", "value": 100},
+                    "obdRunTime": {"timestamp": "2025-08-08T18:01:42Z", "value": 799},
+                    "obdStatusDTCCount": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": 1,
+                    },
+                    "powertrainCombustionEngineECT": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": 30,
+                    },
+                    "powertrainCombustionEngineMAF": {
+                        "timestamp": "2024-12-02T07:20:11Z",
+                        "value": 0.05,
+                    },
+                    "powertrainCombustionEngineSpeed": {
+                        "timestamp": "2025-08-08T18:45:53Z",
+                        "value": 16383,
+                    },
+                    "powertrainCombustionEngineTPS": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": 0,
+                    },
+                    "powertrainFuelSystemAbsoluteLevel": {
+                        "timestamp": "2025-02-27T14:24:36Z",
+                        "value": 0,
+                    },
+                    "powertrainFuelSystemRelativeLevel": {
+                        "timestamp": "2025-08-08T18:01:57Z",
+                        "value": 81.17647058823529,
+                    },
+                    "powertrainRange": {
+                        "timestamp": "2024-07-19T16:45:16.517921Z",
+                        "value": 39,
+                    },
+                    "powertrainTractionBatteryChargingIsCharging": {
+                        "timestamp": "2024-07-19T16:45:16.517921Z",
+                        "value": 1,
+                    },
+                    "powertrainTractionBatteryRange": {
+                        "timestamp": "2025-02-27T13:57:07Z",
+                        "value": 0.125,
+                    },
+                    "powertrainTractionBatteryStateOfChargeCurrent": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": 95,
+                    },
+                    "powertrainTransmissionTravelledDistance": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": 11800,
+                    },
+                    "powertrainType": {
+                        "timestamp": "2025-08-08T18:48:44Z",
+                        "value": "COMBUSTION",
+                    },
+                    "speed": {"timestamp": "2025-08-08T18:48:44Z", "value": 0},
+                },
             }
         }
     }
@@ -103,30 +239,8 @@ def test_dimo_client_get_latest_signals():
     # Assert the result matches the query result
     assert result == query_result
 
-    # Assert the query was constructed correctly
-    expected_query = f"""
-        query {{
-            signalsLatest(tokenId: {token_id}) {{
-                speed {{
-                  timestamp
-                  value
-                }}
-                batteryLevel {{
-                  timestamp
-                  value
-                }}
-            }}
-        }}
-    """
-
-    # Normalize whitespace for comparison
-    actual_query = dimo_mock.telemetry.query.call_args[0][0]  # Get the actual query
-    assert "".join(actual_query.split()) == "".join(
-        expected_query.split()
-    ), f"Query mismatch.\nExpected:\n{expected_query}\nActual:\n{actual_query}"
-
-    # Ensure privileged token was used
-    dimo_mock.telemetry.query.assert_called_once_with(actual_query, priv_token.token)
+    # Make sure the full query was batched into two queries
+    assert dimo_mock.telemetry.query.call_count == 2
     auth_mock.get_privileged_token.assert_called_once_with(token_id)
 
 

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -96,7 +96,7 @@ def test_dimo_client_get_latest_signals():
     }
     dimo_mock.telemetry.query.return_value = query_result
 
-    result = dimo_client.get_latest_signals(token_id, signal_names)
+    result = dimo_client.get_latest_signals_batched(token_id, signal_names)
 
     # Assert the result matches the query result
     assert result == query_result

--- a/tests/test_dimo_client.py
+++ b/tests/test_dimo_client.py
@@ -89,9 +89,11 @@ def test_dimo_client_get_latest_signals():
     token_id = "123"
     signal_names = ["speed", "batteryLevel"]
     query_result = {
-        "signalsLatest": {
-            "speed": {"timestamp": "2024-11-27T12:00:00Z", "value": 60},
-            "batteryLevel": {"timestamp": "2024-11-27T12:00:00Z", "value": 80},
+        "data": {
+            "signalsLatest": {
+                "speed": {"timestamp": "2024-11-27T12:00:00Z", "value": 60},
+                "batteryLevel": {"timestamp": "2024-11-27T12:00:00Z", "value": 80},
+            }
         }
     }
     dimo_mock.telemetry.query.return_value = query_result


### PR DESCRIPTION
DIMO has recently intoduced a (conservative) complexity limit for Graphql queries. For vehicles with a large number of signals we end up exceeding this limit when we query for the values of all signals.

To work around this issue we can chunk up the queries and merge the responses in order to get all signal values

Fixes #199