### PR TITLE
fix: corrected DIMO python sdk version in manifest

### DIFF
--- a/custom_components/dimo/manifest.json
+++ b/custom_components/dimo/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ardevd/ha-dimo/issues",
   "requirements": [
-    "dimo-python-sdk==1.4.0"
+    "dimo-python-sdk==1.5.0"
   ],
   "single_config_entry": true,
   "version": "0.10.2"


### PR DESCRIPTION
the previous attempt to update to v1.5.0 of the DIMO Python SDK only updated the test requirements and didnt actually update the manifest.