### PR TITLE
fix: moved vehicle `available` property to vehicle specific entity class

### DIFF
--- a/custom_components/dimo/base_entity.py
+++ b/custom_components/dimo/base_entity.py
@@ -66,12 +66,6 @@ class DimoBaseEntity(CoordinatorEntity):
         """Return extra state attributes."""
         return {}
 
-    @property
-    def available(self) -> bool:
-        """Return whether data is available for this entity."""
-        vehicle = self.coordinator.vehicle_data.get(self.vehicle_token_id)
-        return bool(vehicle and vehicle.signal_data.get(self.key))
-
 
 class DimoBaseVehicleEntity(DimoBaseEntity):
     """Base representation of a vehicle entity."""
@@ -102,6 +96,12 @@ class DimoBaseVehicleEntity(DimoBaseEntity):
     def state_class(self) -> SensorStateClass | str | None:
         """Return the state class of this entity, if any."""
         return self._signal.state_class if self._signal else None
+
+    @property
+    def available(self) -> bool:
+        """Return whether data is available for this entity."""
+        vehicle = self.coordinator.vehicle_data.get(self.vehicle_token_id)
+        return bool(vehicle and vehicle.signal_data.get(self.key))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/dimo/dimoapi/dimo_client.py
+++ b/custom_components/dimo/dimoapi/dimo_client.py
@@ -5,8 +5,11 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from .auth import Auth
-from .queries import (GET_ALL_VEHICLES_QUERY, GET_LATEST_SIGNALS_QUERY,
-                      GET_VEHICLE_REWARDS_QUERY)
+from .queries import (
+    GET_ALL_VEHICLES_QUERY,
+    GET_LATEST_SIGNALS_QUERY,
+    GET_VEHICLE_REWARDS_QUERY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -230,7 +233,7 @@ class DimoClient:
             )
             return None
         except Exception as e:
-            _LOGGER.error(f"Failed to get total DIMO vehicles: {e}")
+            _LOGGER.error(f"Failed to get total DIMO vehicles count: {e}")
             return None
 
     @requires_vehicle_jwt


### PR DESCRIPTION
The `DimoBaseEntity` is used by the vehicle-agnostic sensor (Total DIMO vehicles) so having the `available` property there breaks those sensors. 

Fixes #234 