### PR TITLE
refactor: added suggested display precision entitiy property

### DIFF
--- a/custom_components/dimo/base_entity.py
+++ b/custom_components/dimo/base_entity.py
@@ -98,6 +98,11 @@ class DimoBaseVehicleEntity(DimoBaseEntity):
         return bool(vehicle and vehicle.signal_data.get(self.key))
 
     @property
+    def suggested_display_precision(self) -> int | None:
+        """Return the suggested precision of this entity."""
+        return self._signal.suggested_display_precision if self._signal else None
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         vehicle_data = self.coordinator.vehicle_data[self.vehicle_token_id]

--- a/custom_components/dimo/const.py
+++ b/custom_components/dimo/const.py
@@ -47,6 +47,7 @@ class SignalDef:
     device_class: SensorDeviceClass | BinarySensorDeviceClass | None = None
     unit_of_measure: str | None = None
     state_class: SensorStateClass | None = None
+    suggested_display_precision: int | None = None
 
 
 @dataclass
@@ -73,6 +74,7 @@ SIGNALS: dict[str, SignalDef] = {
         SensorDeviceClass.VOLTAGE,
         UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
     ),
     "isIgnitionOn": SignalDef(
         "Ignition",


### PR DESCRIPTION
added display precision specifier and applied it to the low voltage battery voltage sensor definition so that the voltage is shown with two decimals by default